### PR TITLE
Added Appropriate .gitattributes File

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,10 +3,16 @@
 # Whitespace settings
 * whitespace=indent-with-non-tab,trailing-space,space-before-tab,tabwidth=4
 
+# F# stuff explicitly is text
+*.fs       text
+*.fsi      text
+*.fsx      text
+*.fsscript text
+
+# CWTools config files are explicitly text
+*.cwt      text
+
 # Setup better diffs
-*.py       text diff=python
-*.py3      text diff=python
-*.pl       text diff=perl
 *.html     text diff=html
 *.xhtml    text diff=html
 *.css      text diff=css
@@ -21,11 +27,7 @@
 *.PDF      text diff=astextplain
 *.rtf      text diff=astextplain
 *.RTF      text diff=astextplain
-*.bibtex   text diff=bibtex
 *.md       text diff=markdown
-*.tex      text diff=tex
-*.rb       text diff=ruby
-*.php      text diff=php
 
 # Scripts
 # These are explicitly linux files and should use lf
@@ -58,4 +60,3 @@
 .gitattributes export-ignore
 .gitignore     export-ignore
 .gitkeep       export-ignore
-

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,61 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+# Whitespace settings
+* whitespace=indent-with-non-tab,trailing-space,space-before-tab,tabwidth=4
+
+# Setup better diffs
+*.py       text diff=python
+*.py3      text diff=python
+*.pl       text diff=perl
+*.html     text diff=html
+*.xhtml    text diff=html
+*.css      text diff=css
+*.scss     text diff=css
+*.doc      text diff=astextplain
+*.DOC      text diff=astextplain
+*.docx     text diff=astextplain
+*.DOCX     text diff=astextplain
+*.dot      text diff=astextplain
+*.DOT      text diff=astextplain
+*.pdf      text diff=astextplain
+*.PDF      text diff=astextplain
+*.rtf      text diff=astextplain
+*.RTF      text diff=astextplain
+*.bibtex   text diff=bibtex
+*.md       text diff=markdown
+*.tex      text diff=tex
+*.rb       text diff=ruby
+*.php      text diff=php
+
+# Scripts
+# These are explicitly linux files and should use lf
+*.bash     text eol=lf
+*.fish     text eol=lf
+*.sh       text eol=lf
+# These are explicitly windows files and should use crlf
+*.bat      text eol=crlf
+*.cmd      text eol=crlf
+*.ps1      text eol=crlf
+
+# Serialisation
+*.json     text
+*.toml     text
+*.xml      text
+*.yaml     text
+*.yml      text
+
+# Archives
+*.7z       binary
+*.gz       binary
+*.tar      binary
+*.tgz      binary
+*.zip      binary
+
+# Text files where line endings should be preserved
+*.patch    -text
+
+# Exclude files from exporting
+.gitattributes export-ignore
+.gitignore     export-ignore
+.gitkeep       export-ignore
+


### PR DESCRIPTION
The newly added .gitattributes file should automatically take care of pesky inconsistencies like line endings, whitespace indents, and indent widths in future commits made by contributors who have their git configs and/or their text editor configs set to something else. It also explicitly enables built-in diff drivers for file types currently used by the repository (or that are likely to be used in the future) that could use them.