### PR TITLE
Adding "list = value[list]" to every_in_local_list

### DIFF
--- a/config/list_effects.cwt
+++ b/config/list_effects.cwt
@@ -1733,6 +1733,7 @@ alias[effect:ordered_heir] = {
 
 ### Iterate through all items in local list. list = name or variable = name every_in_local_list = { limit = { <triggers> } <effects> }
 alias[effect:every_in_local_list] = {
+    list = value[list]
     ## cardinality = 0..1
     limit = {
         alias_name[trigger] = alias_match_left[trigger]


### PR DESCRIPTION
This was missing from the definition, and is causing errors when you use list = xyz in every_in_local_list.