### PR TITLE
Update trait config

### DIFF
--- a/config/common/traits.cwt
+++ b/config/common/traits.cwt
@@ -19,9 +19,6 @@ trait = {
     name = localisation
     ## cardinality = 0..1
     name = single_alias_right[complex_desc]
-    ## cardinality = 1..1
-    ### Trait index. Must be unique.
-    index = int
     ## cardinality = 0..1
     icon = single_alias_right[complex_desc]
     ## cardinality = 0..inf


### PR DESCRIPTION
Indexes in traits are no longer needed, quote from .info file:

```
# old_trait_indexes.lookup contains the ordered list of named traits to match up with the pre 1.4 manual indexes traits had to assign.
# Nulls fill the gaps between the valid entries.
# Make sure to adjust this for your mods traits when relasing for 1.4 if you want your saves from 1.3 to be compatible. If you did not edit the traits or are going to break compatibility then leave it as is.
```